### PR TITLE
emove extraneous argument to use_ok

### DIFF
--- a/t/03_request.t
+++ b/t/03_request.t
@@ -9,7 +9,7 @@ plan skip_all => "Catalyst::Request required for this test"
     
 plan tests => 3;
 
-use_ok("WWW::ClickSource::Request","WWW::ClickSource::Request loaded");
+use_ok("WWW::ClickSource::Request");
 
 
 {

--- a/t/04_catalyst_request.t
+++ b/t/04_catalyst_request.t
@@ -9,8 +9,8 @@ plan skip_all => "Catalyst::Request required for this test"
     
 plan tests => 6;
 
-use_ok("WWW::ClickSource::Request","WWW::ClickSource::Request loaded");
-use_ok('WWW::ClickSource::Request::CatalystRequest','WWW::ClickSource::Request::CatalystRequest loaded');
+use_ok("WWW::ClickSource::Request");
+use_ok('WWW::ClickSource::Request::CatalystRequest');
 
 
 {


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.